### PR TITLE
Support elision in extractor expression cover grammar

### DIFF
--- a/spec.emu
+++ b/spec.emu
@@ -261,10 +261,11 @@ contributors: Ron Buckton, Ecma International
         1. Return « *"\*default\*"* ».
       </emu-alg>
       <emu-grammar>
-        CoverCallExpressionAndAsyncArrowHead : MemberExpression Arguments
+        <del>CoverCallExpressionAndAsyncArrowHead : MemberExpression Arguments</del>
+        <ins>CoverCallExpressionAndAsyncArrowHeadAndExtractor : MemberExpression CoverCallAndExtractorArguments</ins>
       </emu-grammar>
       <emu-alg>
-        1. Let _head_ be the |AsyncArrowHead| that is covered by |CoverCallExpressionAndAsyncArrowHead|.
+        1. Let _head_ be the |AsyncArrowHead| that is covered by <del>|CoverCallExpressionAndAsyncArrowHead|</del><ins>|CoverCallExpressionAndAsyncArrowHeadAndExtractor|</ins>.
         1. Return the BoundNames of _head_.
       </emu-alg>
       <emu-grammar>ImportDeclaration : `import` ImportClause FromClause `;`</emu-grammar>
@@ -660,7 +661,8 @@ contributors: Ron Buckton, Ecma International
         `new` NewExpression[?Yield, ?Await]
 
       CallExpression[Yield, Await] :
-        CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await] #callcover
+        <del>CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await]</del>
+        <ins>CoverCallExpressionAndAsyncArrowHeadAndExtractor[?Yield, ?Await] #callcover</ins>
         SuperCall[?Yield, ?Await]
         ImportCall[?Yield, ?Await]
         CallExpression[?Yield, ?Await] Arguments[?Yield, ?Await]
@@ -674,6 +676,13 @@ contributors: Ron Buckton, Ecma International
 
       ImportCall[Yield, Await] :
         `import` `(` AssignmentExpression[+In, ?Yield, ?Await] `)`
+
+      <ins class="block">
+      CoverCallAndExtractorArguments[Yield, Await] :
+        `(` Elision? `)`
+        `(` ElementList[?Yield, ?Await] `)`
+        `(` ElementList[?Yield, ?Await] `,` Elision? `)`
+      </ins>
 
       Arguments[Yield, Await] :
         `(` `)`
@@ -711,8 +720,11 @@ contributors: Ron Buckton, Ecma International
     <h2>Supplemental Syntax</h2>
     <p>
       When processing an instance of the production<br>
-      <emu-grammar>CallExpression : CoverCallExpressionAndAsyncArrowHead</emu-grammar><br>
-      the interpretation of |CoverCallExpressionAndAsyncArrowHead| is refined using the following grammar:
+      <emu-grammar>
+        <del>CallExpression : CoverCallExpressionAndAsyncArrowHead</del>
+        <ins>CallExpression : CoverCallExpressionAndAsyncArrowHeadAndExtractor</ins>
+      </emu-grammar><br>
+      the interpretation of <del>|CoverCallExpressionAndAsyncArrowHead|</del><ins>|CoverCallExpressionAndAsyncArrowHeadAndExtractor|</ins> is refined using the following grammar:
     </p>
     <emu-grammar type="definition">
       CallMemberExpression[Yield, Await] :
@@ -724,9 +736,12 @@ contributors: Ron Buckton, Ecma International
 
       <emu-clause id="sec-function-calls-runtime-semantics-evaluation" type="sdo">
         <h1>Runtime Semantics: Evaluation</h1>
-        <emu-grammar>CallExpression : CoverCallExpressionAndAsyncArrowHead</emu-grammar>
+        <emu-grammar>
+          <del>CallExpression : CoverCallExpressionAndAsyncArrowHead</del>
+          <ins>CallExpression : CoverCallExpressionAndAsyncArrowHeadAndExtractor</ins>
+        </emu-grammar>
         <emu-alg>
-          1. Let _expr_ be the |CallMemberExpression| that is covered by |CoverCallExpressionAndAsyncArrowHead|.
+          1. Let _expr_ be the |CallMemberExpression| that is covered by <del>|CoverCallExpressionAndAsyncArrowHead|</del><ins>|CoverCallExpressionAndAsyncArrowHeadAndExtractor|</ins>.
           1. Let _memberExpr_ be the |MemberExpression| of _expr_.
           1. Let _arguments_ be the |Arguments| of _expr_.
           1. Let _ref_ be ? Evaluation of _memberExpr_.
@@ -765,10 +780,10 @@ contributors: Ron Buckton, Ecma International
       <emu-grammar>AssignmentExpression : LeftHandSideExpression `=` AssignmentExpression</emu-grammar>
       <ul>
         <li>
-          If |LeftHandSideExpression| is either an |ObjectLiteral|<del> or</del><ins>,</ins> an |ArrayLiteral|<ins>, or a |CoverCallExpressionAndAsyncArrowHead|</ins>, |LeftHandSideExpression| must cover an |AssignmentPattern|.
+          If |LeftHandSideExpression| is either an |ObjectLiteral|<del> or</del><ins>,</ins> an |ArrayLiteral|<ins>, or a |CoverCallExpressionAndAsyncArrowHeadAndExtractor|</ins>, |LeftHandSideExpression| must cover an |AssignmentPattern|.
         </li>
         <li>
-          If |LeftHandSideExpression| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, nor a |CoverCallExpressionAndAsyncArrowHead|</ins>, it is a Syntax Error if the AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
+          If |LeftHandSideExpression| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, nor a |CoverCallExpressionAndAsyncArrowHeadAndExtractor|</ins>, it is a Syntax Error if the AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
         </li>
       </ul>
       <emu-grammar>
@@ -789,7 +804,7 @@ contributors: Ron Buckton, Ecma International
       <h1>Runtime Semantics: Evaluation</h1>
       <emu-grammar>AssignmentExpression : LeftHandSideExpression `=` AssignmentExpression</emu-grammar>
       <emu-alg>
-        1. If |LeftHandSideExpression| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, nor a |CoverCallExpressionAndAsyncArrowHead|</ins>, then
+        1. If |LeftHandSideExpression| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, nor a |CoverCallExpressionAndAsyncArrowHeadAndExtractor|</ins>, then
           1. Let _lref_ be ? Evaluation of |LeftHandSideExpression|.
           1. If IsAnonymousFunctionDefinition(|AssignmentExpression|) and IsIdentifierRef of |LeftHandSideExpression| are both *true*, then
             1. Let _rval_ be ? NamedEvaluation of |AssignmentExpression| with argument _lref_.[[ReferencedName]].
@@ -951,16 +966,16 @@ contributors: Ron Buckton, Ecma International
         <emu-grammar>AssignmentRestProperty : `...` DestructuringAssignmentTarget</emu-grammar>
         <ul>
           <li>
-            It is a Syntax Error if |DestructuringAssignmentTarget| is either an |ArrayLiteral|<del> or</del><ins>,</ins> an |ObjectLiteral|<ins>, or a |CoverCallExpressionAndAsyncArrowHead|</ins>.
+            It is a Syntax Error if |DestructuringAssignmentTarget| is either an |ArrayLiteral|<del> or</del><ins>,</ins> an |ObjectLiteral|<ins>, or a |CoverCallExpressionAndAsyncArrowHeadAndExtractor|</ins>.
           </li>
         </ul>
         <emu-grammar>DestructuringAssignmentTarget : LeftHandSideExpression</emu-grammar>
         <ul>
           <li>
-            If |LeftHandSideExpression| is either an |ObjectLiteral|<del> or</del><ins>,</ins> an |ArrayLiteral|<ins>, or a |CoverCallExpressionAndAsyncArrowHead|</ins>, |LeftHandSideExpression| must cover an |AssignmentPattern|.
+            If |LeftHandSideExpression| is either an |ObjectLiteral|<del> or</del><ins>,</ins> an |ArrayLiteral|<ins>, or a |CoverCallExpressionAndAsyncArrowHeadAndExtractor|</ins>, |LeftHandSideExpression| must cover an |AssignmentPattern|.
           </li>
           <li>
-            If |LeftHandSideExpression| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, nor a |CoverCallExpressionAndAsyncArrowHead|</ins>, it is a Syntax Error if the AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
+            If |LeftHandSideExpression| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, nor a |CoverCallExpressionAndAsyncArrowHeadAndExtractor|</ins>, it is a Syntax Error if the AssignmentTargetType of |LeftHandSideExpression| is not ~simple~.
           </li>
         </ul>
       </emu-clause>
@@ -1174,7 +1189,7 @@ contributors: Ron Buckton, Ecma International
         </emu-alg>
         <emu-grammar>AssignmentElement : DestructuringAssignmentTarget Initializer?</emu-grammar>
         <emu-alg>
-          1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, nor a |CoverCallExpressionAndAsyncArrowHead|</ins>, then
+          1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, nor a |CoverCallExpressionAndAsyncArrowHeadAndExtractor|</ins>, then
             1. Let _lref_ be ? Evaluation of |DestructuringAssignmentTarget|.
           1. Let _value_ be *undefined*.
           1. If _iteratorRecord_.[[Done]] is *false*, then
@@ -1189,7 +1204,7 @@ contributors: Ron Buckton, Ecma International
               1. Let _v_ be ? GetValue(_defaultValue_).
           1. Else,
             1. Let _v_ be _value_.
-          1. If |DestructuringAssignmentTarget| is either an |ObjectLiteral|<del> or</del><ins>,</ins> an |ArrayLiteral|<ins>, or a |CoverCallExpressionAndAsyncArrowHead|</ins>, then
+          1. If |DestructuringAssignmentTarget| is either an |ObjectLiteral|<del> or</del><ins>,</ins> an |ArrayLiteral|<ins>, or a |CoverCallExpressionAndAsyncArrowHeadAndExtractor|</ins>, then
             1. Let _nestedAssignmentPattern_ be the |AssignmentPattern| that is covered by |DestructuringAssignmentTarget|.
             1. Return ? DestructuringAssignmentEvaluation of _nestedAssignmentPattern_ with argument _v_.
           1. Return ? PutValue(_lref_, _v_).
@@ -1199,7 +1214,7 @@ contributors: Ron Buckton, Ecma International
         </emu-note>
         <emu-grammar>AssignmentRestElement : `...` DestructuringAssignmentTarget</emu-grammar>
         <emu-alg>
-          1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, nor a |CoverCallExpressionAndAsyncArrowHead|</ins>, then
+          1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, nor a |CoverCallExpressionAndAsyncArrowHeadAndExtractor|</ins>, then
             1. Let _lref_ be ? Evaluation of |DestructuringAssignmentTarget|.
           1. Let _A_ be ! ArrayCreate(0).
           1. Let _n_ be 0.
@@ -1208,7 +1223,7 @@ contributors: Ron Buckton, Ecma International
             1. If _next_ is not ~done~, then
               1. Perform ! CreateDataPropertyOrThrow(_A_, ! ToString(𝔽(_n_)), _next_).
               1. Set _n_ to _n_ + 1.
-          1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, nor a |CoverCallExpressionAndAsyncArrowHead|</ins>, then
+          1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, nor a |CoverCallExpressionAndAsyncArrowHeadAndExtractor|</ins>, then
             1. Return ? PutValue(_lref_, _A_).
           1. Let _nestedAssignmentPattern_ be the |AssignmentPattern| that is covered by |DestructuringAssignmentTarget|.
           1. Return ? DestructuringAssignmentEvaluation of _nestedAssignmentPattern_ with argument _A_.
@@ -1226,7 +1241,7 @@ contributors: Ron Buckton, Ecma International
         </dl>
         <emu-grammar>AssignmentElement : DestructuringAssignmentTarget Initializer?</emu-grammar>
         <emu-alg>
-          1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, nor a |CoverCallExpressionAndAsyncArrowHead|</ins>, then
+          1. If |DestructuringAssignmentTarget| is neither an |ObjectLiteral|<del> nor</del><ins>,</ins> an |ArrayLiteral|<ins>, nor a |CoverCallExpressionAndAsyncArrowHeadAndExtractor|</ins>, then
             1. Let _lref_ be ? Evaluation of |DestructuringAssignmentTarget|.
           1. Let _v_ be ? GetV(_value_, _propertyName_).
           1. If |Initializer| is present and _v_ is *undefined*, then
@@ -1237,7 +1252,7 @@ contributors: Ron Buckton, Ecma International
               1. Let _rhsValue_ be ? GetValue(_defaultValue_).
           1. Else,
             1. Let _rhsValue_ be _v_.
-          1. If |DestructuringAssignmentTarget| is either an |ObjectLiteral|<del> or</del><ins>,</ins> an |ArrayLiteral|<ins>, or a |CoverCallExpressionAndAsyncArrowHead|</ins>, then
+          1. If |DestructuringAssignmentTarget| is either an |ObjectLiteral|<del> or</del><ins>,</ins> an |ArrayLiteral|<ins>, or a |CoverCallExpressionAndAsyncArrowHeadAndExtractor|</ins>, then
             1. Let _assignmentPattern_ be the |AssignmentPattern| that is covered by |DestructuringAssignmentTarget|.
             1. Return ? DestructuringAssignmentEvaluation of _assignmentPattern_ with argument _rhsValue_.
           1. Return ? PutValue(_lref_, _rhsValue_).
@@ -1326,4 +1341,47 @@ contributors: Ron Buckton, Ecma International
       </emu-grammar>
     </emu-clause>
   </emu-clause>
+</emu-clause>
+
+<emu-clause id="sec-ecmascript-language-functions-and-classes">
+  <h1>ECMAScript Language: Functions and Classes</h1>
+  <emu-clause id="sec-async-arrow-function-definitions">
+    <h1>Async Arrow Function Definitions</h1>
+    <h2>Syntax</h2>
+    <emu-grammar type="definition">
+      AsyncArrowFunction[In, Yield, Await] :
+        `async` [no LineTerminator here] AsyncArrowBindingIdentifier[?Yield] [no LineTerminator here] `=>` AsyncConciseBody[?In]
+        <del>CoverCallExpressionAndAsyncArrowHead[?Yield, ?Await] [no LineTerminator here] `=>` AsyncConciseBody[?In]</del>
+        <ins>CoverCallExpressionAndAsyncArrowHeadAndExtractor[?Yield, ?Await] [no LineTerminator here] `=>` AsyncConciseBody[?In] #callcover</ins>
+
+      AsyncConciseBody[In] :
+        [lookahead != `{`] ExpressionBody[?In, +Await]
+        `{` AsyncFunctionBody `}`
+
+      AsyncArrowBindingIdentifier[Yield] :
+        BindingIdentifier[?Yield, +Await]
+
+      <del class="block">
+      CoverCallExpressionAndAsyncArrowHead[Yield, Await] :
+        MemberExpression[?Yield, ?Await] Arguments[?Yield, ?Await]
+      </del>
+      <ins class="block">
+      CoverCallExpressionAndAsyncArrowHeadAndExtractor[Yield, Await] :
+        MemberExpression[?Yield, ?Await] CoverCallAndExtractorArguments[?Yield, ?Await]
+      </ins>
+    </emu-grammar>
+    <h2>Supplemental Syntax</h2>
+    <p>
+      When processing an instance of the production<br>
+      <emu-grammar>
+        <del>AsyncArrowFunction : CoverCallExpressionAndAsyncArrowHead `=>` AsyncConciseBody</del>
+        <ins>AsyncArrowFunction : CoverCallExpressionAndAsyncArrowHeadAndExtractor `=>` AsyncConciseBody</ins>
+      </emu-grammar><br>
+      the interpretation of <del>|CoverCallExpressionAndAsyncArrowHead|</del><ins>|CoverCallExpressionAndAsyncArrowHeadAndExtractor|</ins> is refined using the following grammar:
+    </p>
+
+    <emu-grammar type="definition">
+      AsyncArrowHead :
+        `async` [no LineTerminator here] ArrowFormalParameters[~Yield, +Await]
+    </emu-grammar>
 </emu-clause>


### PR DESCRIPTION
This changes the grammar to use a cover for _Arguments_ that includes the _Elision_ elements necessary to support _ExtractorAssignmentPattern_.

Fixes #23